### PR TITLE
consolidate german language files

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,8 +2,12 @@ name: Pull request labeler
 on:
   schedule:
     - cron: '0 12 */1 * *'
+permissions:
+  contents: read
 jobs:
   labeler:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: paulfantom/periodic-labeler@master


### PR DESCRIPTION
I noted that for the german translations, in many modules, the files were named 'de-DE' instead of just 'de'.
Worse still, there existed 'de' files alongside which duplicated some translations, but many entries that were present in 'de-DE' were missing in the 'de' files altogether.
I have cleaned up by consolidating 'de-DE' into 'de' and removing the locale-specific 'de-DE' files.
So that they can be used by other locales like 'de-CH' (Swiss german) properly.

BTW, English seems to be similarly messy. There are 'en' and 'en-GB' files all over the place, mostly duplicating translations.